### PR TITLE
FANZA取得追加、各種のサイト取得をconfirmXXXのツールで一元化

### DIFF
--- a/confirm_fanza.py
+++ b/confirm_fanza.py
@@ -1,0 +1,12 @@
+from src import site
+from src import tool
+from src import db
+
+jav_dao = db.jav.JavDao()
+
+javs = jav_dao.get_where_agreement('WHERE id = 15867') # MACB-001
+fanza = site.fanza.Fanza()
+p_tool = tool.p_number.ProductNumber()
+# p_number, seller, sell_date, match_maker, ng_reason = p_tool.parse_and_fc2(javs[0], True)
+site_data = fanza.get_info('SDMU-912')
+# site_data.print()

--- a/confirm_p_number.py
+++ b/confirm_p_number.py
@@ -1,0 +1,34 @@
+from src import site
+from src import tool
+from src import db
+from src import common
+
+jav_dao = db.jav.JavDao()
+
+javs = jav_dao.get_where_agreement('WHERE is_selection = 9 order by created_at desc limit 100')
+
+parser = common.AutoMakerParser()
+
+print('target [' + str(len(javs)) + ']')
+p_tool = tool.p_number.ProductNumber()
+err_list = []
+for jav in javs:
+    print('p_number ' + jav.productNumber)
+    p_number, seller, sell_date, match_maker, ng_reason = p_tool.parse_and_fc2(jav, True)
+
+    if match_maker is None:
+        msg = 'no match makerId[' + str(jav.makersId) + ']'
+        err_list.append(msg)
+        print(msg)
+        continue
+    if jav.makersId != match_maker.id:
+        msg = 'no match makerId[' + str(jav.makersId + ']  match_maker [' + str(match_maker.id))
+        err_list.append(msg)
+        print(msg)
+    else:
+        msg = 'same_maker'
+        # err_list.append(msg)
+        # print(msg)
+
+for err in err_list:
+    print(err)

--- a/confirm_recover.py
+++ b/confirm_recover.py
@@ -6,7 +6,7 @@ from src import common
 jav_dao = db.jav.JavDao()
 
 # fc2 = site.fc2.Fc2()
-# mgs = site.mgs.Mgs()
+mgs = site.mgs.Mgs()
 javs = jav_dao.get_where_agreement('WHERE is_parse2 <= 0 and is_selection = 1')
 
 parser = common.AutoMakerParser()
@@ -16,17 +16,53 @@ p_tool = tool.p_number.ProductNumber(is_log_print=False)
 err_list = []
 ok_cnt = 0
 ng_cnt = 0
+is_checked = True
 for jav in javs:
 
-    match_maker, ng_reason = p_tool.parse(jav, True)
+    match_maker, ng_reason = p_tool.parse(jav, is_checked)
 
     if ng_reason > 0:
-        match_maker.print()
+        # match_maker.print()
+        p_tool.get_log_print()
         ok_cnt = ok_cnt + 1
     else:
         err_list.append(str(jav.id) + ' [' + str(ng_reason) + '] ' + jav.title)
         err_list.append('    ' + str(p_tool.get_log_print()))
         ng_cnt = ng_cnt + 1
+        # -1 : メーカー名に一致するmaker無し
+        # -3 : メーカー一致が複数件、match_strに一致するmaker無し
+        #   メーカーに登録
+        if ng_reason == -1 or ng_reason == -3:
+            try:
+                new_maker = parser.get_maker(jav)
+                new_maker.print()
+                p_tool.append_maker(new_maker)
+            except common.MatchStrSameError as err:
+                print(str(err))
+        #   -2 : メーカー名1件だけ完全一致したが、match_strの文字列がtitleにない
+        #   -21 : タイトル内にpNumberは存在したが、一致するメーカーは存在しない
+        if ng_reason == -21:
+            hey_p_number, hey_label = p_tool.get_p_number_hey(jav.title)
+
+            if len(hey_p_number) > 0:
+                err_list.append('      【' + hey_p_number + '】 ' + hey_label)
+            else:
+                p_number = p_tool.get_maker_match_number(None, jav.title)
+                site_data = mgs.get_info(p_number)
+
+                if site_data is None or len(site_data.productNumber) <= 0:
+                    err_list.append('      MGSには存在しない ' + jav.title)
+                    continue
+                try:
+                    new_maker = parser.get_maker_from_site(site_data, 'MGS')
+                    if new_maker is not None:
+                        err_list.append('   ' + new_maker.get_print_list('    ')[0])
+                        p_tool.append_maker(new_maker)
+                except common.MatchStrSameError as err:
+                    print(str(err))
+                except common.MatchStrNotFoundError as err:
+                    print(jav.title)
+                    print(str(err))
 
     '''
     print('p_number ' + jav.productNumber)

--- a/confirm_recover.py
+++ b/confirm_recover.py
@@ -1,0 +1,51 @@
+from src import site
+from src import tool
+from src import db
+from src import common
+
+jav_dao = db.jav.JavDao()
+
+# fc2 = site.fc2.Fc2()
+# mgs = site.mgs.Mgs()
+javs = jav_dao.get_where_agreement('WHERE is_parse2 <= 0 and is_selection = 1')
+
+parser = common.AutoMakerParser()
+
+print('target [' + str(len(javs)) + ']')
+p_tool = tool.p_number.ProductNumber(is_log_print=False)
+err_list = []
+ok_cnt = 0
+ng_cnt = 0
+for jav in javs:
+
+    match_maker, ng_reason = p_tool.parse(jav, True)
+
+    if ng_reason > 0:
+        match_maker.print()
+        ok_cnt = ok_cnt + 1
+    else:
+        err_list.append(str(jav.id) + ' [' + str(ng_reason) + '] ' + jav.title)
+        err_list.append('    ' + str(p_tool.get_log_print()))
+        ng_cnt = ng_cnt + 1
+
+    '''
+    print('p_number ' + jav.productNumber)
+    if jav.isParse2 == -3 or jav.isParse2 == -4:
+        continue
+
+    p_number, seller, sell_date, match_maker, ng_reason = p_tool.parse_and_fc2(jav, True)
+
+    print('seller_date ' + str(sell_date) + '  seller ' + seller)
+    if ng_reason < 0:
+        if mgs.exist_product_number(jav.productNumber):
+            site_data = mgs.get_info(jav.productNumber)
+            if site_data is not None:
+                continue
+        err_list.append(str(jav.id) + ' failed [' + str(ng_reason) + ']  ' + jav.title)
+    '''
+
+for err in err_list:
+    print(err)
+
+print('ok [' + str(ok_cnt) + ']')
+print('ng [' + str(ng_cnt) + ']')

--- a/confirm_recover.py
+++ b/confirm_recover.py
@@ -10,11 +10,13 @@ maker_dao = db.maker.MakerDao()
 mgs = site.mgs.Mgs()
 hey = site.hey.Hey()
 fanza = site.fanza.Fanza()
-# javs = jav_dao.get_where_agreement('WHERE is_parse2 <= 0 and is_selection = 1 order by id limit 50')
-javs = jav_dao.get_where_agreement('WHERE is_parse2 <= 0 and is_selection = 1 and id <= 16546 order by id limit 50')
+javs = jav_dao.get_where_agreement('WHERE is_parse2 <= 0 and is_selection = 1 order by id')
+# javs = jav_dao.get_where_agreement('WHERE is_parse2 <= 0 and is_selection = 1 and id <= 17143 order by id limit 50')
 
 parser = common.AutoMakerParser()
 
+if javs is None:
+    javs = []
 print('target [' + str(len(javs)) + ']')
 p_tool = tool.p_number.ProductNumber(is_log_print=False)
 err_list = []
@@ -79,7 +81,9 @@ for jav in javs:
                 makers = maker_dao.get_where_agreement('WHERE label = %s', (site_data.maker, ))
 
                 if makers is not None:
-                    err_list.append('      【' + site_data.maker + '】はmakerに存在 maker_id [' + str(makers[0].id))
+                    err_list.append('      [' + site_data.streamDate + '] 【' + site_data.maker + '】')
+                    err_list.append('      HEY【' + site_data.maker + '】はmakerに存在 maker_id ['
+                                    + str(makers[0].id) + ']')
                     continue
 
                 err_list.append('      [' + site_data.streamDate + '] 【' + site_data.maker + '】')

--- a/confirm_recover.py
+++ b/confirm_recover.py
@@ -4,9 +4,11 @@ from src import db
 from src import common
 
 jav_dao = db.jav.JavDao()
+maker_dao = db.maker.MakerDao()
 
 # fc2 = site.fc2.Fc2()
 mgs = site.mgs.Mgs()
+hey = site.hey.Hey()
 javs = jav_dao.get_where_agreement('WHERE is_parse2 <= 0 and is_selection = 1')
 
 parser = common.AutoMakerParser()
@@ -19,6 +21,8 @@ ng_cnt = 0
 is_checked = True
 for jav in javs:
 
+    if jav.id == 14651:
+        print('abc')
     match_maker, ng_reason = p_tool.parse(jav, is_checked)
 
     if ng_reason > 0:
@@ -26,26 +30,50 @@ for jav in javs:
         p_tool.get_log_print()
         ok_cnt = ok_cnt + 1
     else:
+        new_maker = None
         err_list.append(str(jav.id) + ' [' + str(ng_reason) + '] ' + jav.title)
         err_list.append('    ' + str(p_tool.get_log_print()))
         ng_cnt = ng_cnt + 1
         # -1 : メーカー名に一致するmaker無し
         # -3 : メーカー一致が複数件、match_strに一致するmaker無し
         #   メーカーに登録
-        if ng_reason == -1 or ng_reason == -3:
+        # -2 : メーカー名1件だけ完全一致したが、match_strの文字列がtitleにない
+        #   完全一致をdelete:1にして、メーカーに登録
+        if ng_reason == -1 or ng_reason == -2 or ng_reason == -3:
+            if ng_reason == -2:
+                # err_list.append('-2発生、1件一致の[' + jav.productNumber + ']deletedを1にする必要あり')
+
+                # deleted : 1 に更新
+                arr_match_str = jav.productNumber.split('-')
+                makers = maker_dao.get_where_agreement('WHERE match_str = %s', (arr_match_str[0]))
+                if makers is not None and len(makers) == 1:
+                    maker_dao.update_deleted(1, makers[0])
+                else:
+                    err_list.append('-2発生、1件一致のmaker [' + jav.productNumber + '] 発見できず')
             try:
                 new_maker = parser.get_maker(jav)
                 new_maker.print()
                 p_tool.append_maker(new_maker)
             except common.MatchStrSameError as err:
                 print(str(err))
-        #   -2 : メーカー名1件だけ完全一致したが、match_strの文字列がtitleにない
+
         #   -21 : タイトル内にpNumberは存在したが、一致するメーカーは存在しない
         if ng_reason == -21:
             hey_p_number, hey_label = p_tool.get_p_number_hey(jav.title)
 
             if len(hey_p_number) > 0:
-                err_list.append('      【' + hey_p_number + '】 ' + hey_label)
+                makers = maker_dao.get_where_agreement('WHERE label = %s', (hey_label, ))
+
+                if makers is not None:
+                    err_list.append('      【' + hey_label + '】はmakerに存在 maker_id [' + str(makers[0].id))
+                    continue
+
+                err_list.append('      [' + hey_p_number + '] 【' + hey_label + '】')
+                site_data = hey.get_info(hey_p_number)
+                if site_data is None or len(site_data.maker) <= 0:
+                    err_list.append('      HEYには存在しない ' + jav.title)
+                    continue
+                err_list.append('      [' + site_data.streamDate + '] 【' + site_data.maker + '】')
             else:
                 p_number = p_tool.get_maker_match_number(None, jav.title)
                 site_data = mgs.get_info(p_number)
@@ -64,21 +92,9 @@ for jav in javs:
                     print(jav.title)
                     print(str(err))
 
-    '''
-    print('p_number ' + jav.productNumber)
-    if jav.isParse2 == -3 or jav.isParse2 == -4:
-        continue
-
-    p_number, seller, sell_date, match_maker, ng_reason = p_tool.parse_and_fc2(jav, True)
-
-    print('seller_date ' + str(sell_date) + '  seller ' + seller)
-    if ng_reason < 0:
-        if mgs.exist_product_number(jav.productNumber):
-            site_data = mgs.get_info(jav.productNumber)
-            if site_data is not None:
-                continue
-        err_list.append(str(jav.id) + ' failed [' + str(ng_reason) + ']  ' + jav.title)
-    '''
+        if new_maker is not None:
+            if not is_checked:
+                maker_dao.export(new_maker)
 
 for err in err_list:
     print(err)

--- a/confirm_recover.py
+++ b/confirm_recover.py
@@ -9,7 +9,9 @@ maker_dao = db.maker.MakerDao()
 # fc2 = site.fc2.Fc2()
 mgs = site.mgs.Mgs()
 hey = site.hey.Hey()
-javs = jav_dao.get_where_agreement('WHERE is_parse2 <= 0 and is_selection = 1')
+fanza = site.fanza.Fanza()
+# javs = jav_dao.get_where_agreement('WHERE is_parse2 <= 0 and is_selection = 1 order by id limit 50')
+javs = jav_dao.get_where_agreement('WHERE is_parse2 <= 0 and is_selection = 1 and id <= 16546 order by id limit 50')
 
 parser = common.AutoMakerParser()
 
@@ -18,17 +20,20 @@ p_tool = tool.p_number.ProductNumber(is_log_print=False)
 err_list = []
 ok_cnt = 0
 ng_cnt = 0
-is_checked = True
+is_checked = False
 for jav in javs:
 
-    if jav.id == 14651:
-        print('abc')
     match_maker, ng_reason = p_tool.parse(jav, is_checked)
 
     if ng_reason > 0:
-        # match_maker.print()
         p_tool.get_log_print()
         ok_cnt = ok_cnt + 1
+        if not is_checked:
+            jav_dao.update_checked_ok(ng_reason, match_maker.id, jav)
+
+        if jav.sellDate is None:
+            print('no sell_date ' + jav.title)
+
     else:
         new_maker = None
         err_list.append(str(jav.id) + ' [' + str(ng_reason) + '] ' + jav.title)
@@ -38,7 +43,7 @@ for jav in javs:
         # -3 : メーカー一致が複数件、match_strに一致するmaker無し
         #   メーカーに登録
         # -2 : メーカー名1件だけ完全一致したが、match_strの文字列がtitleにない
-        #   完全一致をdelete:1にして、メーカーに登録
+        #   match_strに完全一致のメーカーをdelete:1にして、新規としてメーカーに登録
         if ng_reason == -1 or ng_reason == -2 or ng_reason == -3:
             if ng_reason == -2:
                 # err_list.append('-2発生、1件一致の[' + jav.productNumber + ']deletedを1にする必要あり')
@@ -47,42 +52,57 @@ for jav in javs:
                 arr_match_str = jav.productNumber.split('-')
                 makers = maker_dao.get_where_agreement('WHERE match_str = %s', (arr_match_str[0]))
                 if makers is not None and len(makers) == 1:
-                    maker_dao.update_deleted(1, makers[0])
+                    if not is_checked:
+                        maker_dao.update_deleted(1, makers[0])
                 else:
                     err_list.append('-2発生、1件一致のmaker [' + jav.productNumber + '] 発見できず')
             try:
                 new_maker = parser.get_maker(jav)
-                new_maker.print()
+                # new_maker.print()
                 p_tool.append_maker(new_maker)
             except common.MatchStrSameError as err:
                 print(str(err))
 
         #   -21 : タイトル内にpNumberは存在したが、一致するメーカーは存在しない
+        p_number = ''
         if ng_reason == -21:
             hey_p_number, hey_label = p_tool.get_p_number_hey(jav.title)
 
             if len(hey_p_number) > 0:
-                makers = maker_dao.get_where_agreement('WHERE label = %s', (hey_label, ))
-
-                if makers is not None:
-                    err_list.append('      【' + hey_label + '】はmakerに存在 maker_id [' + str(makers[0].id))
-                    continue
 
                 err_list.append('      [' + hey_p_number + '] 【' + hey_label + '】')
                 site_data = hey.get_info(hey_p_number)
                 if site_data is None or len(site_data.maker) <= 0:
-                    err_list.append('      HEYには存在しない ' + jav.title)
+                    err_list.append('      HEYのp_number[ ' + hey_p_number + ']だが、HEYには存在しない ' + jav.title)
                     continue
+
+                makers = maker_dao.get_where_agreement('WHERE label = %s', (site_data.maker, ))
+
+                if makers is not None:
+                    err_list.append('      【' + site_data.maker + '】はmakerに存在 maker_id [' + str(makers[0].id))
+                    continue
+
                 err_list.append('      [' + site_data.streamDate + '] 【' + site_data.maker + '】')
+                new_maker = parser.get_maker_hey(hey_p_number, site_data)
+                p_number = hey_p_number
+
             else:
                 p_number = p_tool.get_maker_match_number(None, jav.title)
                 site_data = mgs.get_info(p_number)
 
+                site_name = 'MGS'
                 if site_data is None or len(site_data.productNumber) <= 0:
                     err_list.append('      MGSには存在しない ' + jav.title)
-                    continue
+                    p_number = p_tool.get_p_number(jav.title)
+                    site_data = fanza.get_info(p_number)
+                    if site_data is None:
+                        err_list.append('    FANZAにも存在しない')
+                        continue
+                    # site_data.print('FANZA ')
+                    site_name = 'FANZA'
+                    site_data.productNumber = jav.productNumber
                 try:
-                    new_maker = parser.get_maker_from_site(site_data, 'MGS')
+                    new_maker = parser.get_maker_from_site(site_data, site_name)
                     if new_maker is not None:
                         err_list.append('   ' + new_maker.get_print_list('    ')[0])
                         p_tool.append_maker(new_maker)
@@ -92,7 +112,27 @@ for jav in javs:
                     print(jav.title)
                     print(str(err))
 
+        if ng_reason == -22:
+            p_number = p_tool.get_p_number(jav.title)
+            site_data = fanza.get_info(p_number)
+            if site_data is None:
+                err_list.append('    FANZAには存在しない')
+            else:
+                err_list.append('    FANZA 【' + site_data.streamDate + '】')
+                # if not is_checked:
+                # jav_dao.update_maker_label(site_data.maker, site_data.label, jav.id)
+
+        if len(jav.productNumber) <= 0:
+            err_list.append('  add p_number [' + p_number + ']')
+
+        if ng_reason == -21 or ng_reason == -22 or ng_reason == -23:
+            if p_number != jav.productNumber:
+                err_list.append('  p_number change [' + p_number + '] <-- [' + jav.productNumber + ']')
+                if not is_checked:
+                    jav_dao.update_product_number(jav.id, p_number)
+
         if new_maker is not None:
+            new_maker.print('NEW ')
             if not is_checked:
                 maker_dao.export(new_maker)
 

--- a/confirm_recover_selldate.py
+++ b/confirm_recover_selldate.py
@@ -1,0 +1,127 @@
+import re
+from src import site
+from src import tool
+from src import db
+from src import common
+
+jav_dao = db.jav.JavDao()
+maker_dao = db.maker.MakerDao()
+
+copytext = common.CopyText()
+fc2 = site.fc2.Fc2()
+mgs = site.mgs.Mgs()
+hey = site.hey.Hey()
+wiki = site.wiki.SougouWiki()
+fanza = site.fanza.Fanza()
+javs = jav_dao.get_where_agreement('WHERE is_selection = 1 and (sell_date is null or sell_date = \'1900-01-01\') '
+                                   'order by post_date limit 100')
+# javs = jav_dao.get_where_agreement('WHERE id = 14532')
+# javs = jav_dao.get_where_agreement('WHERE is_parse2 <= 0 and is_selection = 1 and id <= 17143 order by id limit 50')
+
+# parser = common.AutoMakerParser()
+makers = maker_dao.get_all()
+
+if javs is None:
+    javs = []
+print('target [' + str(len(javs)) + ']')
+p_tool = tool.p_number.ProductNumber(is_log_print=False)
+err_list = []
+ok_cnt = 0
+ng_cnt = 0
+is_checked = True
+for jav in javs:
+
+    site_data = None
+    find_filter_maker = filter(lambda maker: maker.id == jav.makersId, makers)
+    find_maker_list = list(find_filter_maker)
+    if len(find_maker_list) <= 0:
+        err_list.append('not found[' + str(jav.id) + ']  ' + str(jav.makersId))
+        ng_cnt = ng_cnt + 1
+        continue
+
+    match_maker = find_maker_list[0]
+    print('[' + str(jav.id) + ']  p_num [' + jav.productNumber + ']' + match_maker.name)
+
+    if match_maker.name == 'HEY動画':
+        site_data = hey.get_info(jav.productNumber)
+
+        if site_data is None:
+            err_list.append('HEY動画 not found[' + str(jav.id) + ']  ' + match_maker.label)
+            ng_cnt = ng_cnt + 1
+            continue
+
+        print(site_data.streamDate + '  ' + site_data.maker)
+
+    elif match_maker.name == 'MGS':
+        site_data = mgs.get_info(jav.productNumber)
+
+        if site_data is None:
+            err_list.append('MGS not found[' + str(jav.id) + ']  ' + jav.title)
+            detail = 'no mgs result'
+            ng_cnt = ng_cnt + 1
+            continue
+
+        print(site_data.streamDate + '  ' + site_data.maker)
+
+    elif match_maker.name == 'FC2 コンテンツマーケット':
+        site_data = fc2.get_info(jav.productNumber)
+
+        if site_data is None:
+            err_list.append('FC2 not found[' + str(jav.id) + ']  ' + jav.title)
+            ng_cnt = ng_cnt + 1
+            continue
+
+        print(site_data.streamDate + '  ' + site_data.maker)
+
+    elif match_maker.name == 'SITE':
+        print('SITE DAYO ' + jav.title)
+        ng_cnt = ng_cnt + 1
+        continue
+
+    else:
+        if match_maker.kind == 1:
+            site_data = fanza.get_info(jav.productNumber)
+
+            if site_data is None:
+                err_list.append('FANZA not found[' + str(jav.id) + ']  ' + jav.title)
+                ng_cnt = ng_cnt + 1
+                continue
+        else:
+            print('URA DAYO ' + jav.title)
+
+    if match_maker.kind == 3:
+        if site_data is not None:
+            # is_siteも1に更新
+            jav_dao.update_site_info(site_data.maker, site_data.streamDate, jav.id)
+            ok_cnt = ok_cnt + 1
+        else:
+            str_date = copytext.get_date_ura(jav.title)
+            if len(str_date) > 0:
+                jav_dao.update_detail_and_sell_date('', str_date, jav.id)
+                ok_cnt = ok_cnt + 1
+            else:
+                print('site_data is None date not found' + jav.title)
+                ng_cnt = ng_cnt + 1
+    else:
+        if site_data is not None:
+            detail = site_data.get_detail()
+            # if jav.maker is None or len(jav.maker) <= 0:
+            #     jav_dao.update_maker_label(match_maker.name, match_maker.label, jav.id)
+            # is_siteも1に更新
+            jav_dao.update_detail_and_sell_date(detail, site_data.streamDate, jav.id)
+
+            if jav.searchResult is None or len(jav.searchResult.strip()) <= 0:
+                searchResult = wiki.search(jav.productNumber)
+                if len(searchResult.strip()) <= 0:
+                    searchResult = 'no search result'
+                jav_dao.update_search_result(searchResult, jav.id)
+            ok_cnt = ok_cnt + 1
+        else:
+            print('site_data is None ' + jav.title)
+            ng_cnt = ng_cnt + 1
+
+for err in err_list:
+    print(err)
+
+print('ok [' + str(ok_cnt) + ']')
+print('ng [' + str(ng_cnt) + ']')

--- a/src/common/__init__.py
+++ b/src/common/__init__.py
@@ -232,6 +232,27 @@ class AutoMakerParser:
         # INSERT INTO replace_info (type, source, destination) VALUES('maker_name', 'プレステージ', 'PreStige');
         # INSERT INTO replace_info (type, source, destination) VALUES('maker_m_name', 'プレステージ', 'プレステージ');
 
+    def get_maker_hey(self, p_number: str = '', site_data: data.SiteData() = None):
+
+        '''
+        INSERT INTO scraping.maker (name, match_name, label, kind, match_str, match_product_number, site_kind, replace_words, p_number_gen, deleted, registered_by)
+          VALUES ('HEY動画', 'HEY動画', 'おじさんの個人撮影', 3, '(4197|おじさんの個人撮影)', 'PPV[0-9]{3}', 0, 'PPV', 1, 0, 'MANUAL 2018-12-23');
+        '''
+        arr_p_number = p_number.split('_')
+        maker = data.MakerData()
+        maker.kind = 3
+        maker.name = 'HEY動画'
+        maker.matchName = 'HEY動画'
+        maker.label = site_data.maker
+        maker.matchLabel = site_data.maker
+        maker.matchStr = '(' + arr_p_number[0] + '|' + site_data.maker + ')'
+        maker.matchProductNumber = '(\-[0-9]{3,4}|PPV[0-9]{3,4}'
+        maker.replaceWords = 'PPV'
+        maker.pNumberGen = 1
+        maker.registeredBy = 'AUTO ' + datetime.now().strftime('%Y-%m-%d')
+
+        return maker
+
     def get_maker(self, jav: data.JavData()):
 
         m_p = re.search('[A-Z0-9]{2,5}-[A-Z0-9]{2,4}', jav.title, re.IGNORECASE)
@@ -293,9 +314,9 @@ class AutoMakerParser:
                 maker.label = site_data.maker
             maker.siteKind = 2
         else:
-            maker.name = site_name
-            maker.matchName = site_name
-            maker.label = site_data.maker
+            maker.name = site_data.maker
+            maker.matchName = site_data.maker
+            maker.label = site_data.label
 
         maker.kind = 1
         maker.matchStr = match_str.upper()
@@ -312,12 +333,12 @@ class AutoMakerParser:
 
     def apply_replace_info(self, target_str: str = '', apply_list: list = None):
 
-        apply_str = ''
+        apply_str = target_str
         for replace_info in self.replace_info_list:
             if apply_list == 'all':
-                apply_str = self.__get_type_replace(target_str, replace_info)
+                apply_str = self.__get_type_replace(apply_str, replace_info)
             if replace_info.type in apply_list:
-                apply_str = self.__get_type_replace(target_str, replace_info)
+                apply_str = self.__get_type_replace(apply_str, replace_info)
 
         return apply_str
 

--- a/src/common/__init__.py
+++ b/src/common/__init__.py
@@ -249,14 +249,16 @@ class AutoMakerParser:
             exist_maker = self.maker_dao.get_exist(match_str.upper())
             if exist_maker:
                 err_msg = '[' + str(jav.id) + '] 発見!! [' + match_str + ']'
-                exist_maker.print()
+                # exist_maker.print()
                 raise MatchStrSameError(err_msg)
 
         maker = data.MakerData()
-        maker.name = jav.maker
+        maker.name = jav.maker.replace('/', '／')
+        maker.matchName = jav.maker.replace('/', '[/／]')
         maker.kind = 1
         maker.matchStr = match_str.upper()
         maker.label = jav.label
+        maker.matchLabel = jav.label
         maker.registeredBy = 'AUTO ' + datetime.now().strftime('%Y-%m-%d')
 
         maker.name = self.apply_replace_info(jav.maker, ('maker_name', 'maker_m_name'))

--- a/src/common/__init__.py
+++ b/src/common/__init__.py
@@ -236,6 +236,9 @@ class AutoMakerParser:
 
         m_p = re.search('[A-Z0-9]{2,5}-[A-Z0-9]{2,4}', jav.title, re.IGNORECASE)
 
+        jav_name = jav.maker.replace('/', '／')
+        jav_label = jav.label.replace('—-', '').replace('/', '／')
+
         if m_p:
             p_number = m_p.group()
             match_str = p_number.split('-')[0]
@@ -253,16 +256,15 @@ class AutoMakerParser:
                 raise MatchStrSameError(err_msg)
 
         maker = data.MakerData()
-        maker.name = jav.maker.replace('/', '／')
-        maker.matchName = jav.maker.replace('/', '[/／]')
         maker.kind = 1
         maker.matchStr = match_str.upper()
-        maker.label = jav.label
-        maker.matchLabel = jav.label
+        maker.matchLabel = jav_label
         maker.registeredBy = 'AUTO ' + datetime.now().strftime('%Y-%m-%d')
 
-        maker.name = self.apply_replace_info(jav.maker, ('maker_name', 'maker_m_name'))
-        maker.label = self.apply_replace_info(jav.label, ('maker_label', 'maker_m_label'))
+        maker.matchName = self.apply_replace_info(jav_name, ('maker_m_name',))
+        maker.name = self.apply_replace_info(jav_name, ('maker_name',))
+        maker.label = self.apply_replace_info(jav_label, ('maker_label',))
+        maker.matchLabel = self.apply_replace_info(jav_label, ('maker_m_label',))
 
         return maker
 
@@ -299,8 +301,12 @@ class AutoMakerParser:
         maker.matchStr = match_str.upper()
         maker.registeredBy = 'AUTO ' + datetime.now().strftime('%Y-%m-%d')
 
-        maker.name = self.apply_replace_info(maker.name, ('maker_name', 'maker_m_name'))
-        maker.label = self.apply_replace_info(maker.label, ('maker_label', 'maker_m_label'))
+        maker.matchName = self.apply_replace_info(maker.name, ('maker_m_name',))
+        maker.name = self.apply_replace_info(maker.name, ('maker_name',))
+        maker.label = self.apply_replace_info(maker.label, ('maker_label',))
+        maker.matchLabel = self.apply_replace_info(maker.label, ('maker_m_label',))
+        maker.name = maker.name.replace('/', '／')
+        maker.label = maker.label.replace('—-', '')
 
         return maker
 

--- a/src/common/__init__.py
+++ b/src/common/__init__.py
@@ -80,6 +80,28 @@ class CopyText:
     def __init__(self, is_debug: bool = False):
         self.is_debug = is_debug
 
+    def get_date_ura(self, title: str = ''):
+
+        str_date = ''
+        try:
+            if 'カリビアン' in title:
+                m_date = re.search('(?P<ura_date>[0-1][0-9][0-3][0-9][0-2][0-9])[_-][0-9]{3,4}', title)
+            elif '天然むすめ' in title:
+                m_date = re.search('(?P<ura_date>[0-1][0-9][0-3][0-9][0-2][0-9])_[0-9]{2}', title)
+            else:
+                m_date = re.search('(?P<ura_date>[0-1][0-9][0-3][0-9][0-2][0-9])_[0-9]{3}', title)
+        except:
+            print(sys.exc_info())
+
+        if m_date:
+            try:
+                sell_date = datetime.strptime(m_date.group('ura_date'), '%m%d%y')
+                str_date = sell_date.strftime('%Y-%m-%d')
+            except:
+                sys.exc_info()
+
+        return str_date
+
     def get_title(self, copy_text: str = '', product_number: str = '', match_maker: data.MakerData = None):
 
         hankaku_kigou = ['/', ':']
@@ -246,7 +268,7 @@ class AutoMakerParser:
         maker.label = site_data.maker
         maker.matchLabel = site_data.maker
         maker.matchStr = '(' + arr_p_number[0] + '|' + site_data.maker + ')'
-        maker.matchProductNumber = '(\-[0-9]{3,4}|PPV[0-9]{3,4}'
+        maker.matchProductNumber = '(\-[0-9]{3,4}|PPV[0-9]{3,4})'
         maker.replaceWords = 'PPV'
         maker.pNumberGen = 1
         maker.registeredBy = 'AUTO ' + datetime.now().strftime('%Y-%m-%d')

--- a/src/data/__init__.py
+++ b/src/data/__init__.py
@@ -239,6 +239,7 @@ class SiteData:
         self.title = ''
         self.actress = ''
         self.maker = ''
+        self.label = ''
         self.duration = ''
         self.productNumber = ''
         self.streamDate = ''
@@ -259,6 +260,7 @@ class SiteData:
         print_list.append(indent + '  title      [' + self.title + ']')
         print_list.append(indent + '  actress    [' + self.actress + ']')
         print_list.append(indent + '  maker      [' + self.maker + ']')
+        print_list.append(indent + '  label      [' + self.label + ']')
         print_list.append(indent + '  duration   [' + self.duration + ']')
         print_list.append(indent + '  pNumber    [' + self.productNumber + ']')
         print_list.append(indent + '  streamDate [' + self.streamDate + ']')

--- a/src/data/__init__.py
+++ b/src/data/__init__.py
@@ -159,6 +159,11 @@ class MakerData:
 
         print_list = []
 
+        if self.name is None:
+            self.name = ''
+
+        if self.label is None:
+            self.label = ''
         print_list.append(indent + '【' + self.name + ':' + self.label + '】')
         print_list.append(indent + '  id       [' + str(self.id) + ']')
         print_list.append(indent + '  kind     [' + str(self.kind) + ']')

--- a/src/data/__init__.py
+++ b/src/data/__init__.py
@@ -135,6 +135,7 @@ class MakerData:
         self.name = ''
         self.matchName = ''
         self.label = ''
+        self.matchLabel = ''
         self.kind = 0
         self.matchStr = ''
         self.matchProductNumber = ''
@@ -168,6 +169,7 @@ class MakerData:
         print_list.append(indent + '  id       [' + str(self.id) + ']')
         print_list.append(indent + '  kind     [' + str(self.kind) + ']')
         print_list.append(indent + '  matchNam [' + self.matchName + ']')
+        print_list.append(indent + '  matchLab [' + self.matchLabel + ']')
         print_list.append(indent + '  matchStr [' + self.matchStr + ']')
         print_list.append(indent + '  matchPNum[' + self.matchProductNumber + ']')
         print_list.append(indent + '  siteKind [' + str(self.siteKind) + ']')

--- a/src/db/jav.py
+++ b/src/db/jav.py
@@ -195,9 +195,13 @@ class JavDao(mysql_base.MysqlBase):
 
     def update_detail_and_sell_date(self, detail: str = '', sell_date: str = '', id: int = 0):
 
+        if len(sell_date) <= 0:
+            sell_date = None
+
         sql = 'UPDATE jav ' \
               '  SET detail = %s ' \
               '    , sell_date = %s ' \
+              '    , is_site = 1 ' \
               '  WHERE id = %s'
 
         self.cursor.execute(sql, (detail, sell_date, id))

--- a/src/db/jav.py
+++ b/src/db/jav.py
@@ -181,6 +181,18 @@ class JavDao(mysql_base.MysqlBase):
 
         self.conn.commit()
 
+    def update_maker_label(self, maker: str = '', label: str = '', id: int = 0):
+
+        sql = 'UPDATE jav ' \
+              '  SET maker = %s ' \
+              '    , label = %s ' \
+              '  WHERE id = %s'
+
+        self.cursor.execute(sql, (maker, label, id))
+        print("jav update id [" + str(id) + "] maker, label")
+
+        self.conn.commit()
+
     def update_detail_and_sell_date(self, detail: str = '', sell_date: str = '', id: int = 0):
 
         sql = 'UPDATE jav ' \

--- a/src/db/maker.py
+++ b/src/db/maker.py
@@ -104,20 +104,31 @@ class MakerDao(mysql_base.MysqlBase):
 
         return exist
 
+    def update_deleted(self, deleted: str = '', id: int = 0):
+
+        sql = 'UPDATE maker ' \
+              '  SET deleted = %s ' \
+              '  WHERE id = %s'
+
+        self.cursor.execute(sql, (deleted, id))
+        print("maker update id [" + str(id) + "] deleted ")
+
+        return
+
     def export(self, maker: data.MakerData):
 
         sql = 'INSERT INTO maker ( ' \
-              '  name, match_name, label, kind ' \
+              '  name, match_name, label, match_label, kind ' \
               '  , match_str, match_product_number, site_kind, replace_words ' \
               '  , p_number_gen, registered_by ' \
               '  ) ' \
               '  VALUES ( ' \
-              '  %s, %s, %s, %s ' \
+              '  %s, %s, %s, %s, %s ' \
               '  , %s, %s, %s, %s ' \
               '  , %s, %s ' \
               '  ) '
 
-        self.cursor.execute(sql, (maker.name, maker.matchName, maker.label, maker.kind
+        self.cursor.execute(sql, (maker.name, maker.matchName, maker.label, maker.matchLabel, maker.kind
                                   , maker.matchStr, maker.matchProductNumber, maker.siteKind, maker.replaceWords
                                   , maker.pNumberGen, maker.registeredBy
                                   ))

--- a/src/db/maker.py
+++ b/src/db/maker.py
@@ -40,10 +40,9 @@ class MakerDao(mysql_base.MysqlBase):
     def __get_sql_select(self, where: str = ''):
 
         sql = 'SELECT id ' \
-              '  , name, match_name, label, kind ' \
-              '  , match_str, match_product_number, site_kind, replace_words ' \
-              '  , p_number_gen, registered_by ' \
-              '  , created_at, updated_at ' \
+              '  , name, match_name, label, match_label ' \
+              '  , kind, match_str, match_product_number, site_kind ' \
+              '  , replace_words, p_number_gen, registered_by ' \
               '  , created_at, updated_at ' \
               '  FROM maker '
 
@@ -63,15 +62,16 @@ class MakerDao(mysql_base.MysqlBase):
             maker.name = row[1]
             maker.matchName = row[2]
             maker.label = row[3]
-            maker.kind = row[4]
-            maker.matchStr = row[5]
-            maker.matchProductNumber = row[6]
-            maker.siteKind = row[7]
-            maker.replaceWords = row[8]
-            maker.pNumberGen = row[9]
-            maker.registeredBy = row[10]
-            maker.createdAt = row[11]
-            maker.updatedAt = row[12]
+            maker.matchLabel = row[4]
+            maker.kind = row[5]
+            maker.matchStr = row[6]
+            maker.matchProductNumber = row[7]
+            maker.siteKind = row[8]
+            maker.replaceWords = row[9]
+            maker.pNumberGen = row[10]
+            maker.registeredBy = row[11]
+            maker.createdAt = row[12]
+            maker.updatedAt = row[13]
             makers.append(maker)
 
         return makers

--- a/src/site/__init__.py
+++ b/src/site/__init__.py
@@ -2,3 +2,4 @@ from . import fc2
 from . import wiki
 from . import mgs
 from . import hey
+from . import fanza

--- a/src/site/fanza.py
+++ b/src/site/fanza.py
@@ -1,0 +1,110 @@
+import re
+import urllib.request
+from bs4 import BeautifulSoup
+from .. import common
+from .. import db
+from .. import data
+
+
+class Fanza:
+
+    def __init__(self):
+        self.main_url = 'https://www.google.com/search?q=fanza+'
+        self.opener = urllib.request.build_opener()
+        self.opener.addheaders = [('User-Agent',
+                                   'Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/36.0.1941.0 Safari/537.36')]
+
+        self.env = common.Environment()
+        self.driver = self.env.get_driver()
+        self.import_dao = db.import_dao.ImportDao()
+
+    def get_info(self, product_number):
+
+        site_data = None
+        url = self.main_url + product_number
+
+        urllib.request.install_opener(self.opener)
+
+        with urllib.request.urlopen(url) as response:
+            html = response.read()
+            google_result_soup = BeautifulSoup(html, "html.parser")
+            div_r_list = google_result_soup.findAll('div', class_='r')
+
+            for idx, div_r in enumerate(div_r_list):
+                a_div_r = div_r.find('a')
+                url = a_div_r['href']
+
+                print('FANZA ' + product_number + ' ' + url)
+                if 'www.dmm.co.jp' in url and '/detail/' in url:
+                    site_data = self.__parse_site_data(url)
+                    break
+
+                if idx > 3:
+                    break
+
+        return site_data
+
+    def __parse_site_data(self, url):
+
+        site_data = None
+        with urllib.request.urlopen(url) as response:
+            html = response.read()
+            html_soup = BeautifulSoup(html, "html.parser")
+
+            table_info = html_soup.find('table', class_='mg-b20')
+            # tr_all = table_info.findAll('tr')
+            tr_all = table_info.findAll('tr')
+            site_data = data.SiteData()
+            h1_title = html_soup.find('h1', id='title')
+            if h1_title:
+                site_data.title = h1_title.text
+            before_name = ''
+            for idx, tr in enumerate(tr_all):
+                for idx_sub, td in enumerate(tr.find_all_next('td')):
+                    # print(str(idx) + ' ' + str(idx_sub) + ' 【' + str(td.text) + '】')
+
+                    if before_name == '発売日':
+                        site_data.streamDate = td.text.strip()
+                        before_name = ''
+                    if re.search('発売日', td.text) or re.search('配信.*日', td.text):
+                        before_name = '発売日'
+
+                    if before_name == 'duration':
+                        site_data.duration = td.text.replace('\n', ' ').strip()
+                        before_name = ''
+                    if re.search('収録時間', td.text):
+                        before_name = 'duration'
+
+                    if before_name == 'actress':
+                        site_data.actress = td.text.replace('\n', '').strip()
+                        before_name = ''
+                    if re.search('出演者', td.text):
+                        before_name = 'actress'
+
+                    if before_name == 'maker':
+                        site_data.maker = td.text.strip()
+                        before_name = ''
+                    if re.search('メーカー', td.text):
+                        before_name = 'maker'
+
+                    if before_name == 'label':
+                        site_data.label = td.text.strip()
+                        before_name = ''
+                    if re.search('レーベル', td.text):
+                        before_name = 'label'
+
+                    if before_name == 'series':
+                        site_data.series = td.text.strip()
+                        before_name = ''
+                    if re.search('シリーズ', td.text):
+                        before_name = 'series'
+
+                # print('tr end')
+                # site_data.print()
+                break
+
+        # site_data.print()
+
+        urllib.request.urlcleanup()
+
+        return site_data

--- a/src/site/mgs.py
+++ b/src/site/mgs.py
@@ -32,7 +32,7 @@ class Mgs:
 
         if h2 is None:
             print('h2 tag none')
-            return detail, sell_date
+            return None
 
         if h2.text == '年齢認証':
             over18yes = self.driver.find_element_by_tag_name('li')

--- a/src/tool/p_number.py
+++ b/src/tool/p_number.py
@@ -6,8 +6,11 @@ from .. import site
 
 class ProductNumber:
 
-    def __init__(self):
+    def __init__(self, is_log_print: bool = True):
         self.makers = []
+
+        self.is_log_print = is_log_print
+        self.log_list = []
 
         self.maker_dao = db.maker.MakerDao()
         self.jav_dao = db.jav.JavDao()
@@ -17,6 +20,224 @@ class ProductNumber:
         self.filter_makers = list(filter(lambda maker:
                                          len(maker.matchProductNumber.strip()) > 0
                                          and len(maker.matchStr) > 0, self.makers))
+
+    def __log_print(self, msg: str = ''):
+
+        if self.is_log_print:
+            print(msg)
+        else:
+            self.log_list.append(msg)
+
+    def get_log_print(self):
+
+        log_list = self.log_list.copy()
+        self.log_list.clear()
+
+        return log_list
+
+    def get_maker_match_number(self, match_maker: data.MakerData(), title: str = ''):
+
+        if match_maker is None:
+            return None
+
+        if len(match_maker.matchProductNumber.strip()) > 0:
+            m = re.search(match_maker.matchProductNumber, title, flags=re.IGNORECASE)
+            p_number = m.group().strip()
+
+        else:
+            match = re.search(match_maker.matchStr + '[-]*[A-Za-z0-9]{2,5}', title, flags=re.IGNORECASE)
+
+            if match:
+                p_number = match.group().upper()
+            else:
+                raise Exception('matchするp_numberがないよー')
+
+        return p_number
+
+    # Javに、メーカー名、レーベルが存在する場合
+    # OK
+    #    1 : メーカー名と一致（レーベル未チェック）
+    #    2 : メーカー名と複数一致で、matchStrと1件だけ一致（レーベル未チェック）
+    #    3 : メーカー名と複数一致で、matchStr・レーベル名と1件だけ一致
+    # NG
+    #   -1 : メーカー名に一致するmaker無し
+    #   -2 : メーカー名1件だけ完全一致したが、match_strの文字列がtitleにない
+    #   -3 : メーカー一致が複数件、match_strに一致するmaker無し
+    #   -4 : メーカー一致が複数件、match_strに複数件、レーベルに一致するmaker無し
+    #   -5 : メーカー・レーベルのどちらにも複数一致
+    def __get_maker_exist_name(self, maker_name: str = '', label_name: str = '', title: str = ''):
+
+        result_maker = None
+        ng_reason = 0
+
+        if len(maker_name.strip()) <= 0:
+            return result_maker, 0
+
+        # jav.makerで検索
+        find_filter_maker = filter(lambda maker: len(maker.matchName) > 0 and re.match(maker.matchName, maker_name),
+                                   self.makers)
+        find_list_maker = list(find_filter_maker)
+
+        if len(find_list_maker) <= 0:
+            self.__log_print('javのメーカ名：ラベル名【' + maker_name + ':' + label_name + '】'
+                             'に一致するメーカーは存在しません ' + title)
+            ng_reason = -1
+            return result_maker, ng_reason
+
+        if len(find_list_maker) == 1:
+            match_maker = find_list_maker[0]
+            # 1つだけの場合は、match_strに文字列が存在するかのチェック
+            if re.search(match_maker.matchStr, title, re.IGNORECASE) or re.search(
+                    match_maker.matchProductNumber, title, re.IGNORECASE):
+                ng_reason = 1
+                result_maker = match_maker
+                self.__log_print('OK メーカー完全一致と、タイトル内に製品番号一致 [' + maker_name + ']' + title)
+            else:
+                ng_reason = -2
+                self.__log_print('NG メーカー完全一致だが、タイトル内に製品番号が一致しない [' + maker_name + ']' + title)
+
+            return result_maker, ng_reason
+
+        # jav.makerが複数件一致した場合はさらに掘り下げる
+
+        # レーベル名より、match_strが一致しているのをまずはチェック
+        find_filter_label = filter(lambda maker: re.search(maker.matchStr + '[\-0-9]', title, re.IGNORECASE),
+                                   find_list_maker)
+        find_list_label = list(find_filter_label)
+        if len(find_list_label) <= 0:
+            self.__log_print('NG メーカー一致が複数件、match_strに一致するmaker無し [' + maker_name + ':' + label_name + ']' + title)
+            ng_reason = -3
+
+            return result_maker, ng_reason
+
+        if len(find_list_label) == 1:
+            result_maker = find_list_label[0]
+            ng_reason = 2
+            self.__log_print('OK メーカーと、タイトル内に製品番号一つだけ一致 [' + maker_name + ':' + label_name + ']' + title)
+
+            return result_maker, ng_reason
+
+        # match_strのチェックが終了して、複数件の場合、レーベル名をチェック
+        if len(label_name) <= 0:
+            find_filter_label = filter(lambda maker: len(maker.label) == 0, find_list_label)
+        else:
+            find_filter_label = filter(lambda maker: maker.label == label_name, find_list_label)
+
+        find_list_label = list(find_filter_label)
+        if len(find_list_label) <= 0:
+            ng_reason = -4
+            self.__log_print('NG メーカー一致が複数件、match_strに複数件、レーベル名に一致するmaker無し ['
+                             + maker_name + ':' + label_name + ']' + title)
+
+            return result_maker, ng_reason
+
+        if len(find_list_label) == 1:
+            result_maker = find_list_label[0]
+            ng_reason = 3
+            self.__log_print('OK メーカーと、タイトル内に製品番号複数一致 & label一致 [' + maker_name + ':' + label_name + ']' + title)
+
+            return result_maker, ng_reason
+
+        # labelにも複数一致した場合
+        ng_reason = -5
+        self.__log_print('NG メーカー・レーベルのどちらにも複数一致 name [' + maker_name + '] label [' + label_name + ']' + title)
+
+        return result_maker, ng_reason
+
+    # Javに、メーカー名、レーベルが存在しない場合
+    # OK
+    #    11 : match_strとmatchProductNumberに1件だけ一致
+    # NG
+    #   -11 : match_strとmatchProductNumberに複数件が一致
+    def __get_maker_not_exist_name(self, title: str = ''):
+
+        ng_reason = 0
+        result_maker = None
+        find_list_maker = []
+        for maker in self.filter_makers:
+            if re.search(maker.matchStr, title, flags=re.IGNORECASE) \
+                    and re.search(maker.matchProductNumber, title, flags=re.IGNORECASE):
+                find_list_maker.append(maker)
+
+        if len(find_list_maker) <= 0:
+            self.__log_print('INFO タイトルからmatchProductNumberに一致するメーカー無し [' + title + ']')
+
+            return result_maker, ng_reason
+
+        if len(find_list_maker) == 1:
+            result_maker = find_list_maker[0]
+            ng_reason = 11
+            self.__log_print(
+                'OK matchProductNumberに1件だけ一致 '
+                '[' + result_maker.matchStr + '] [' + result_maker.matchProductNumber + '] ' + title)
+
+            return result_maker, ng_reason
+
+        self.__log_print('NG タイトルからmatchProductNumberに複数一致 [' + title + ']')
+        ng_reason = -11
+
+        return result_maker, ng_reason
+
+    # こいつは最後の砦なので、ng_reasonに0はリターンしない
+    # Javに情報がないので、productNumberをタイトル内から取得して、チェック
+    # OK
+    #    21 : タイトル内にpNumberと1件だけ一致
+    # NG
+    #   -21 : タイトル内にpNumberは存在したが、一致するメーカーは存在しない
+    #   -22 : タイトル内にpNumberは存在、複数件のメーカーが一致
+    #   -23 : タイトル内にpNumberらしき文字列【[0-9A-Za-z]*-[0-9A-Za-z]】*が存在しない
+    def __get_match_maker_force(self, title: str = ''):
+
+        match = re.search('[0-9A-Za-z]*-[0-9A-Za-z]*', title)
+        result_maker = None
+
+        if match:
+            p_number = match.group().strip()
+            p_maker = p_number.split('-')[0]
+
+            find_filter_maker = filter(lambda maker: maker.matchStr.upper() == p_maker.upper(), self.makers)
+            find_list_maker = list(find_filter_maker)
+
+            if len(find_list_maker) <= 0:
+                ng_reason = -21
+                self.__log_print('NG タイトル内の製品番号[' + p_number + ']に一致するメーカー無し ' + title)
+
+                return result_maker, ng_reason
+
+            if len(find_list_maker) == 1:
+                result_maker = find_list_maker[0]
+                ng_reason = 21
+                self.__log_print('OK タイトル内の製品番号[' + p_number + ']に1件だけメーカー一致 ' + title)
+
+                return result_maker, ng_reason
+
+            ng_reason = -22
+            self.__log_print('NG タイトル内の製品番号[' + p_number + ']に複数一致 ' + title)
+
+        else:
+            ng_reason = -23
+            self.__log_print('NG タイトル内に製品番号【[0-9A-Za-z]*-[0-9A-Za-z]*】の文字列が存在しない [' + title)
+
+        return result_maker, ng_reason
+
+    def parse(self, jav: data.JavData, is_check):
+
+        match_maker, ng_reason = self.__get_maker_exist_name(jav.maker, jav.label, jav.title)
+
+        if ng_reason == 0:
+            match_maker, ng_reason = self.__get_maker_not_exist_name(jav.title)
+
+        if ng_reason == 0:
+            match_maker, ng_reason = self.__get_match_maker_force(jav.title)
+
+        if ng_reason > 0:
+            if not is_check:
+                self.jav_dao.update_checked_ok(ng_reason, match_maker.id, jav)
+        else:
+            if not is_check:
+                self.jav_dao.update_checked_ok(ng_reason, 0, jav)
+
+        return match_maker, ng_reason
 
     def parse_and_fc2(self, jav: data.JavData, is_check):
 
@@ -48,12 +269,12 @@ class ProductNumber:
                 match_maker = find_list_maker[0]
                 if re.search(match_maker.matchStr, jav.title, re.IGNORECASE) or re.search(
                         match_maker.matchProductNumber, jav.title, re.IGNORECASE):
-                    print('OK メーカー完全一致と、タイトル内に製品番号一致 [' + jav.maker + ']' + jav.title)
+                    self.__log_print('OK メーカー完全一致と、タイトル内に製品番号一致 [' + jav.maker + ']' + jav.title)
                     if not is_check:
                         ng_reason = 1
                         self.jav_dao.update_checked_ok(ng_reason, match_maker.id, jav)
                 else:
-                    print('NG メーカー完全一致だが、タイトル内に製品番号が一致しない [' + jav.maker + ']' + jav.title)
+                    self.__log_print('NG メーカー完全一致だが、タイトル内に製品番号が一致しない [' + jav.maker + ']' + jav.title)
                     ng_reason = -1
                     is_nomatch = True
 
@@ -65,7 +286,7 @@ class ProductNumber:
                 len_label = len(find_list_label)
                 if len_label == 1:
                     match_maker = find_list_label[0]
-                    print('OK メーカーと、タイトル内に製品番号一つだけ一致 [' + jav.maker + ':' + jav.label + ']' + jav.title)
+                    self.__log_print('OK メーカーと、タイトル内に製品番号一つだけ一致 [' + jav.maker + ':' + jav.label + ']' + jav.title)
                     if not is_check:
                         ng_reason = 2
                         self.jav_dao.update_checked_ok(ng_reason, match_maker.id, jav)
@@ -77,23 +298,23 @@ class ProductNumber:
                     find_list_label = list(find_filter_label)
                     if len(find_list_label) == 1:
                         match_maker = find_list_label[0]
-                        print('OK メーカーと、タイトル内に製品番号複数一致 & label一致 [' + jav.maker + ':' + jav.label + ']' + jav.title)
+                        self.__log_print('OK メーカーと、タイトル内に製品番号複数一致 & label一致 [' + jav.maker + ':' + jav.label + ']' + jav.title)
                         if not is_check:
                             ng_reason = 3
                             self.jav_dao.update_checked_ok(ng_reason, match_maker.id, jav)
                     else:
-                        print('NG メーカーと、タイトル内に製品番号複数一致 [' + jav.maker + ']' + jav.title)
+                        self.__log_print('NG メーカーと、タイトル内に製品番号複数一致 [' + jav.maker + ']' + jav.title)
                         ng_reason = -2
                 else:
                     # juyなど、Madonnaとマドンナで英語日本語でマッチしない場合はここにくる
-                    print('NG ' + str(len(find_list_maker)) + ' メーカーには複数一致、製品番号に一致しない ID [' + str(
+                    self.__log_print('NG ' + str(len(find_list_maker)) + ' メーカーには複数一致、製品番号に一致しない ID [' + str(
                         jav.id) + '] jav [' + jav.maker + ':' + jav.label + ']' + '  maker [' + find_list_maker[
                               0].name + ']' + jav.title)
                     ng_reason = -3
                     is_nomatch = True
-                # print(str(len(find_list_maker)) + ' ' + jav.maker)
+                # self.__log_print(str(len(find_list_maker)) + ' ' + jav.maker)
             else:
-                print('maker exist no match, not register [' + jav.maker + ':' + jav.label + '] ' + jav.title)
+                self.__log_print('maker exist no match, not register [' + jav.maker + ':' + jav.label + '] ' + jav.title)
                 ng_reason = -4
                 is_nomatch = True
 
@@ -104,7 +325,8 @@ class ProductNumber:
                     p_number = match.group().upper()
                 else:
                     is_nomatch = True
-                    print('メーカー[' + str(match_maker.id) + '] に一致したが、タイトル内に[' + match_maker.matchStr + '] の文字列がない ' + jav.title)
+                    self.__log_print('メーカー[' + str(
+                        match_maker.id) + '] に一致したが、タイトル内に[' + match_maker.matchStr + '] の文字列がない ' + jav.title)
                     ng_reason = -5
 
         # javのメーカ名が無い場合
@@ -131,7 +353,7 @@ class ProductNumber:
                 p_number = m.group().strip()
                 if not match_maker.label:
                     match_maker.label = ''
-                print(
+                self.__log_print(
                     'OK jav.maker無し 製品番号に1件だけ一致 [' + p_number + ']' + match_maker.name + ':' + match_maker.label + ' ' + jav.title)
 
                 if match_maker.pNumberGen == 1:
@@ -140,7 +362,7 @@ class ProductNumber:
                     if m_m:
                         m_number = m_m.group()
                     else:
-                        print("HEY動画のmakerのmatchStrの列が(4083|本生素人TV)の形式になっていません")
+                        self.__log_print("HEY動画のmakerのmatchStrの列が(4083|本生素人TV)の形式になっていません")
                         exit(-1)
                     p_number = m_number.replace('(', '') + '_' + m.group().replace('PPV', '')
                 else:
@@ -149,10 +371,10 @@ class ProductNumber:
                     ng_reason = 4
                     self.jav_dao.update_checked_ok(ng_reason, match_maker.id, jav)
             elif len(find_list_maker) > 1:
-                print(str(len(find_list_maker)) + ' many match ' + jav.title)
+                self.__log_print(str(len(find_list_maker)) + ' many match ' + jav.title)
                 ng_reason = -6
             elif len(find_list_maker) <= 0:
-                # print(str(len(find_list_maker)) + ' no match ' + jav.title)
+                # self.__log_print(str(len(find_list_maker)) + ' no match ' + jav.title)
                 is_nomatch = True
                 ng_reason = -7
 
@@ -160,7 +382,7 @@ class ProductNumber:
                 if match_maker is not None:
                     if match_maker.siteKind == 1:
                         seller, sell_date = self.fc2.get_info(p_number)
-                        # print('    ' + seller + ' ' + sell_date)
+                        # self.__log_print('    ' + seller + ' ' + sell_date)
 
         # HEY動画でAV9898など配信名しか入っていない場合の処理
         '''
@@ -170,7 +392,7 @@ class ProductNumber:
                                        self.makers)
             find_list_label = list(find_filter_label)
             if len(find_list_label) > 0:
-                print(jav.title)
+                self.__log_print(jav.title)
         '''
 
         if ng_reason < 0:
@@ -188,14 +410,15 @@ class ProductNumber:
                 find_list_maker = list(find_filter_maker)
                 if len(find_list_maker) == 1:
                     match_maker = find_list_maker[0]
-                    print(
-                        'OK 製品番号PARSE maker.matchStrに1件だけ一致 [' + p_maker + ']' + match_maker.name + ':' + match_maker.label)
+                    self.__log_print(
+                        'OK 製品番号PARSE maker.matchStrに1件だけ一致 [' + p_number + ']  match_str [' + p_maker + ']' + match_maker.name + ':' + match_maker.label)
+                    ng_reason = 5
                     if not is_check:
-                        ng_reason = 5
                         self.jav_dao.update_checked_ok(ng_reason, match_maker.id, jav)
                 if len(find_list_maker) > 1:
-                    print('NG 製品番号PARSE maker.matchStrに複数一致 [' + str(jav.id) + '] ' + jav.title)
+                    self.__log_print('NG 製品番号PARSE maker.matchStrに複数一致 [' + str(jav.id) + '] ' + jav.title)
                 if len(find_list_maker) <= 0:
-                    print('NG [' + str(jav.id) + '] is_nomatch メーカー[' + jav.maker + ':' + jav.label + ']  は、movie_makersに存在しない  ' + jav.title)
+                    self.__log_print('NG [' + str(
+                        jav.id) + '] is_nomatch メーカー[' + jav.maker + ':' + jav.label + ']  は、movie_makersに存在しない  ' + jav.title)
 
         return p_number, seller, sell_date, match_maker, ng_reason

--- a/src/tool/p_number.py
+++ b/src/tool/p_number.py
@@ -1,4 +1,5 @@
 import re
+import traceback
 from .. import db
 from .. import data
 from .. import site
@@ -59,15 +60,14 @@ class ProductNumber:
         m2 = re.search('4[0-9]{3}-[0-9]{3,4}', title)
         if m1 or m2:
             if m1:
-                p_number = m1.group()
+                p_number = m1.group().replace('-', '_').replace('PPV', '')
             else:
-                p_number = m2.group()
+                p_number = m2.group().replace('-', '_')
 
         if len(p_number) > 0:
             label = re.sub(p_number + '.*', '', title)
 
         return p_number, label
-
 
     def get_maker_match_number(self, match_maker: data.MakerData(), title: str = ''):
 
@@ -155,8 +155,8 @@ class ProductNumber:
         if len(label_name) <= 0:
             find_filter_label = filter(lambda maker: len(maker.label) == 0, find_list_label)
         else:
-            find_filter_label = filter(lambda maker: re.search(maker.matchLabel + '[\-0-9]', label_name, re.IGNORECASE)
-                                       , find_list_label)
+            find_filter_label = filter(lambda maker: re.search(maker.matchLabel, label_name, re.IGNORECASE)
+                                       and len(maker.matchLabel) > 0, find_list_label)
 
         find_list_label = list(find_filter_label)
         if len(find_list_label) <= 0:
@@ -256,6 +256,11 @@ class ProductNumber:
 
     def parse(self, jav: data.JavData, is_check):
 
+        i = 0
+        if jav.id == 17144:
+        #     m1 = re.search('(G-AREA|GAREA)', jav.title, flags=re.IGNORECASE)
+        #     m2 = re.search('[0-9]{3,4}[a-zA-Z]{1,8}', jav.title, flags=re.IGNORECASE)
+            i = 1
         edit_label = jav.label.replace('—-', '')
         match_maker, ng_reason = self.__get_maker_exist_name(jav.maker, edit_label, jav.title)
 

--- a/src/tool/p_number.py
+++ b/src/tool/p_number.py
@@ -40,6 +40,10 @@ class ProductNumber:
 
         return log_list
 
+    def get_p_number(self, title: str = ''):
+
+        return self.__get_p_number(title)
+
     def __get_p_number(self, title: str = ''):
 
         match = re.search('[0-9A-Za-z]*-[0-9A-Za-z]*', title)
@@ -256,11 +260,6 @@ class ProductNumber:
 
     def parse(self, jav: data.JavData, is_check):
 
-        i = 0
-        if jav.id == 17144:
-        #     m1 = re.search('(G-AREA|GAREA)', jav.title, flags=re.IGNORECASE)
-        #     m2 = re.search('[0-9]{3,4}[a-zA-Z]{1,8}', jav.title, flags=re.IGNORECASE)
-            i = 1
         edit_label = jav.label.replace('—-', '')
         match_maker, ng_reason = self.__get_maker_exist_name(jav.maker, edit_label, jav.title)
 
@@ -269,13 +268,16 @@ class ProductNumber:
 
         if ng_reason == 0:
             match_maker, ng_reason = self.__get_match_maker_force(jav.title)
+            p_number = self.__get_p_number(jav.title)
 
+        '''
         if ng_reason > 0:
             if not is_check:
                 self.jav_dao.update_checked_ok(ng_reason, match_maker.id, jav)
         else:
             if not is_check:
                 self.jav_dao.update_checked_ok(ng_reason, 0, jav)
+        '''
 
         return match_maker, ng_reason
 


### PR DESCRIPTION
p_number.ProductNumber１にparseを追加、既存のparse_and_fc2から置き換えのため
jav.is_parse2がマイナスの場合の処理をconfirm_recoverとして同パッケージから実行可能
サイト情報（maker, sell_date）の取得をconfirm_selldateとして同パッケージから実行可能
kind=3のproductNumberからの日付取得追加 get_data_ura
サイト情報の戻りは全てsite_dataへ統一（fc2もtuple(selldate,seller)から変更）
maker.match_labelを追加、レーベル名も正規表現一致可能
