### PR TITLE
リカバリー処理の一元化

### DIFF
--- a/confirm_recover.py
+++ b/confirm_recover.py
@@ -11,7 +11,7 @@ mgs = site.mgs.Mgs()
 hey = site.hey.Hey()
 fanza = site.fanza.Fanza()
 javs = jav_dao.get_where_agreement('WHERE is_parse2 <= 0 and is_selection = 1 order by id')
-# javs = jav_dao.get_where_agreement('WHERE id = 16892 order by id limit 50')
+# javs = jav_dao.get_where_agreement('WHERE id = 16997 order by id limit 50')
 
 parser = common.AutoMakerParser()
 

--- a/confirm_recover2.py
+++ b/confirm_recover2.py
@@ -1,0 +1,71 @@
+from src import tool
+from src import db
+from src import common
+from src import site
+
+jav_dao = db.jav.JavDao()
+maker_dao = db.maker.MakerDao()
+
+javs = jav_dao.get_where_agreement('WHERE is_selection = 1 and search_result is null order by id')
+# javs = jav_dao.get_where_agreement('WHERE is_parse2 <= 0 and is_selection = 1 order by id')
+# javs = jav_dao.get_where_agreement('WHERE id in (19745, 18496) order by id limit 50')
+
+site_collect = site.SiteInfoCollect()
+site_collect.initialize()
+
+site_getter = site.SiteInfoGetter(site_collect=site_collect)
+
+parser = common.AutoMakerParser(maker_dao=maker_dao)
+makers = maker_dao.get_all()
+recover = tool.recover.Recover(site_collect=site_collect, makers=makers)
+
+if javs is None:
+    javs = []
+print('target [' + str(len(javs)) + ']')
+p_tool = tool.p_number.ProductNumber(is_log_print=False)
+err_list = []
+ok_cnt = 0
+ng_cnt = 0
+is_checked = False
+for jav in javs:
+
+    p_number, match_maker, ng_reason = p_tool.parse(jav, is_checked)
+    print('p_number [' + p_number + '] ng_reason [' + str(ng_reason) + ']')
+
+    if ng_reason > 0:
+        # p_tool.get_log_print()
+        ok_cnt = ok_cnt + 1
+        if not is_checked:
+            jav_dao.update_checked_ok(ng_reason, match_maker.id, jav)
+
+        if jav.sellDate is None:
+            print('no sell_date ' + jav.title)
+
+        site_data = site_getter.get_info(jav, match_maker)
+
+        if site_data is None:
+            err_list.append('id [' + str(jav.id) + '] site_data is None 【' + jav.title + '】')
+        else:
+            detail = site_data.get_detail()
+            if not is_checked:
+                jav_dao.update_detail_and_sell_date(detail, site_data.streamDate, jav.id)
+            # site_data = data.SiteData()
+            print('site found [' + detail + ']')
+            result_search = site_getter.get_wiki(jav, match_maker)
+            print('result_search [' + result_search + ']')
+            if not is_checked:
+                jav_dao.update_search_result(result_search.strip(), jav.id)
+
+    else:
+        try:
+            new_maker, site_data = recover.get_ng_new_maker(p_number, ng_reason, jav)
+            if new_maker is not None:
+                new_maker.print('NEW ')
+                if not is_checked:
+                    maker_dao.export(new_maker)
+        except tool.recover.RecoverError as rerr:
+            err_list.append(str(rerr))
+
+for err in err_list:
+    print(err)
+

--- a/confirm_site.py
+++ b/confirm_site.py
@@ -1,0 +1,41 @@
+from src import site
+from src import db
+
+# import_dao = db.import_dao.ImportDao()
+jav_dao = db.jav.JavDao()
+maker_dao = db.maker.MakerDao()
+
+google = site.wiki.Google()
+site_info = site.wiki.Site()
+mgs = site.mgs.Mgs()
+
+'''
+import_list = import_dao.get_where_agreement('WHERE id = 5750')
+for import_data in import_list:
+    if '[裏' in import_data.filename:
+        print('URA not target')
+        continue
+
+    if len(import_data.filename) <= 0:
+        print('filename is not setting')
+        continue
+        
+    if 'SITE：' in import_data.filename:
+        site_name, site_url = site_info.get_info()
+    site_name, site_url = google.get_info(import_data.productNumber)
+    search_result = site_name + ' ' + site_url
+    # print('result ' + site_name + ' ' + site_url)
+    # print('search_result ' + import_data.searchResult)
+
+'''
+makers = maker_dao.get_all()
+
+javs = jav_dao.get_where_agreement('WHERE id = 17603')
+for jav in javs:
+
+    if jav.makersId > 0:
+        match_makers = list(filter(lambda maker:
+                             maker.id == jav.makersId, makers))
+        if len(match_makers) > 0:
+            site_name, site_url = site_info.get_info(match_makers[0])
+            print('result ' + site_name + ' ' + site_url)

--- a/src/common/__init__.py
+++ b/src/common/__init__.py
@@ -336,6 +336,8 @@ class AutoMakerParser:
                 maker.label = site_data.maker
             maker.siteKind = 2
         else:
+            if site_data.maker == site_data.label:
+                site_data.label = ''
             maker.name = site_data.maker
             maker.matchName = site_data.maker
             maker.label = site_data.label

--- a/src/data/__init__.py
+++ b/src/data/__init__.py
@@ -218,6 +218,15 @@ class ImportData:
         self.size = 0
 
 
+class SiteInfoData:
+
+    def __init__(self, name: str = '', matchStr: str = '', url = ''):
+
+        self.id = -1
+        self.name = name
+        self.matchStr = matchStr
+        self.url = url
+
 class ReplaceInfoData:
 
     def __init__(self):

--- a/src/data/__init__.py
+++ b/src/data/__init__.py
@@ -216,6 +216,7 @@ class ImportData:
         self.postDate = None
         self.rating = 0
         self.size = 0
+        self.javId = 0
 
 
 class SiteInfoData:

--- a/src/db/import_dao.py
+++ b/src/db/import_dao.py
@@ -95,14 +95,14 @@ class ImportDao(mysql_base.MysqlBase):
                 ', tag, filename, hd_kind, movie_file_id' \
                 ', split_flag, name_only_flag, package, thumbnail ' \
                 ', download_files, jav_url, rating, size' \
-                ', search_result, detail) ' \
+                ', search_result, detail, jav_id) ' \
                 ' VALUES(%s, %s' \
                 ', %s, %s, %s, %s' \
                 ', %s, %s, %s, %s' \
                 ', %s, %s, %s, %s' \
                 ', %s, %s, %s, %s' \
                 ', %s, %s, %s, %s' \
-                ', %s, %s)'
+                ', %s, %s, %s)'
 
         self.cursor.execute(sql, (import_data.copy_text, import_data.postDate
                             , import_data.kind, import_data.matchStr, import_data.productNumber, import_data.sellDate
@@ -110,7 +110,7 @@ class ImportDao(mysql_base.MysqlBase):
                             , import_data.tag, import_data.filename, import_data.hd_kind, 0
                             , import_data.isSplit, import_data.isNameOnly, import_data.package, import_data.thumbnail
                             , import_data.downloadFiles, import_data.url, import_data.rating, import_data.size
-                            , import_data.searchResult, import_data.detail))
+                            , import_data.searchResult, import_data.detail, import_data.javId))
 
         self.conn.commit()
 

--- a/src/site/__init__.py
+++ b/src/site/__init__.py
@@ -3,3 +3,93 @@ from . import wiki
 from . import mgs
 from . import hey
 from . import fanza
+from .. import data
+from .. import common
+
+
+class SiteInfoCollect:
+
+    def __init__(self):
+        self.fanza = None
+        self.fc2 = None
+        self.hey = None
+        self.mgs = None
+        self.sougou_wiki = None
+        self.google_wiki = None
+        self.site_wiki = None
+        self.copy_text = common.CopyText(False)
+
+    def initialize(self):
+
+        if self.sougou_wiki is None:
+            self.sougou_wiki = wiki.SougouWiki()
+            self.google_wiki = wiki.Google()
+            self.site_wiki = wiki.Site()
+
+        if self.fanza is None:
+            self.fanza = fanza.Fanza()
+
+        if self.fc2 is None:
+            self.fc2 = fc2.Fc2()
+
+        if self.hey is None:
+            self.hey = hey.Hey()
+
+        if self.mgs is None:
+            self.mgs = mgs.Mgs()
+
+
+class SiteInfoGetter:
+
+    def __init__(self, site_collect: SiteInfoCollect = None, is_debug: bool = False):
+        self.is_debug = is_debug
+
+        if site_collect is None:
+            self.site_collect = SiteInfoCollect()
+            self.site_collect.initialize()
+        else:
+            self.site_collect = site_collect
+
+    def get_info(self, jav: data.JavData = None, match_maker: data.MakerData = None):
+
+        site_data = None
+
+        if site_data is None and 'HEY動画' in match_maker.name:
+            site_data = self.site_collect.hey.get_info(jav.productNumber)
+
+        if site_data is None and 'MGS' in match_maker.name:
+            site_data = self.site_collect.mgs.get_info(jav.productNumber)
+
+        if site_data is None and 'FC2' in match_maker.name:
+            site_data = self.site_collect.fc2.get_info(jav.productNumber)
+
+        if site_data is None and match_maker.kind == 1:
+            if match_maker.siteKind != 3 and match_maker.siteKind != 4:
+                site_data = self.site_collect.fanza.get_info(jav.productNumber)
+
+            if site_data is None:
+                title = self.site_collect.copy_text.get_title(jav.title, jav.productNumber, match_maker)
+                site_data = self.site_collect.fanza.get_info_from_title(title)
+
+        return site_data
+
+    def get_wiki(self, jav: data.JavData = None, match_maker: data.MakerData = None):
+
+        if match_maker.kind != 1:
+            return ''
+
+        if match_maker.name == 'SITE':
+            site_name, site_url = self.site_collect.site_wiki.get_info(match_maker)
+            result_search = site_name + ' ' + site_url
+        else:
+            if match_maker.siteKind == 3:
+                result_search = self.site_collect.sougou_wiki.search(jav.productNumber)
+            # elif match_maker.siteKind == 0:
+            else:
+                site_name, site_url = self.site_collect.google_wiki.get_info(jav.productNumber)
+                result_search = site_name + ' ' + site_url
+
+                if len(site_name) <= 0:
+                    result_search = self.site_collect.sougou_wiki.search(jav.productNumber)
+
+        return result_search

--- a/src/site/fanza.py
+++ b/src/site/fanza.py
@@ -9,7 +9,7 @@ from .. import data
 class Fanza:
 
     def __init__(self):
-        self.main_url = 'https://www.google.com/search?q=fanza+'
+        self.main_url = 'https://www.google.com/search?q=fanza+av+'
         self.opener = urllib.request.build_opener()
         self.opener.addheaders = [('User-Agent',
                                    'Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/36.0.1941.0 Safari/537.36')]

--- a/src/site/hey.py
+++ b/src/site/hey.py
@@ -29,26 +29,30 @@ class Hey:
 
             urllib.request.install_opener(self.opener)
 
-            with urllib.request.urlopen(url) as response:
-                html = response.read()
-                html_soup = BeautifulSoup(html, "html.parser")
-                movie_info = html_soup.find('div', id='movie-info')
-                # print(movie_info.text)
-                site_data = data.SiteData()
-                for line in movie_info.text.splitlines():
-                    if re.search('配信日', line):
-                        site_data.streamDate = re.sub('配信日：', '', line).strip()
-                    if re.search('提供元', line):
-                        site_data.maker = re.sub('提供元：|[(（] 公式サイト [)）]', '', line).strip()
-                    if re.search('主演', line):
-                        site_data.actress = re.sub('主演：', '', line).strip()
-                    if re.search('動画再生時間', line):
-                        site_data.duration = re.sub('動画再生時間：', '', line).strip()
-                    if re.search('ファイル容量', line):
-                        site_data.fileSize = re.sub('ファイル容量：', '', line)
-                    if re.search('画面サイズ', line):
-                        site_data.screenSize = re.sub('画面サイズ：', '', line)
-                # site_data.print()
+            try:
+                with urllib.request.urlopen(url) as response:
+                    html = response.read()
+                    html_soup = BeautifulSoup(html, "html.parser")
+                    movie_info = html_soup.find('div', id='movie-info')
+                    # print(movie_info.text)
+                    site_data = data.SiteData()
+                    for line in movie_info.text.splitlines():
+                        if re.search('配信日', line):
+                            site_data.streamDate = re.sub('配信日：', '', line).strip()
+                        if re.search('提供元', line):
+                            site_data.maker = re.sub('提供元：|[(（] 公式サイト [)）]', '', line).strip()
+                        if re.search('主演', line):
+                            site_data.actress = re.sub('主演：', '', line).strip()
+                        if re.search('動画再生時間', line):
+                            site_data.duration = re.sub('動画再生時間：', '', line).strip()
+                        if re.search('ファイル容量', line):
+                            site_data.fileSize = re.sub('ファイル容量：', '', line)
+                        if re.search('画面サイズ', line):
+                            site_data.screenSize = re.sub('画面サイズ：', '', line)
+                    # site_data.print()
+            except urllib.error.HTTPError as err:
+                print('HTTPError [' + str(err.code) + ']')
+
         else:
             print('not found')
 

--- a/src/site/wiki.py
+++ b/src/site/wiki.py
@@ -6,6 +6,25 @@ from .. import common
 from .. import data
 
 
+class Site:
+
+    def __init__(self):
+        self.main_url = 'https://www.google.com/search?q=wiki+av+'
+        self.site_list = []
+        self.site_list.append(data.SiteInfoData('S-CUTE 600', '', 'http://sougouwiki.com/d/S-Cute%20Girls%206'))
+
+    def get_info(self, maker: data.MakerData() = None):
+
+        if maker.name == 'SITE':
+            site_info_list = list(filter(lambda site_info:
+                                  maker.label in site_info.name, self.site_list))
+
+            if len(site_info_list) > 0:
+                return site_info_list[0].name, site_info_list[0].url
+
+        return '', ''
+
+
 class Google:
 
     def __init__(self, max_result: int = 5):
@@ -167,7 +186,7 @@ class SougouWiki:
                     a = wiki.find('a')
                     # print(str(idx), str(a))
                     url = a['href']
-                    wiki_list.append(a.text + ' ' + url)
+                    wiki_list.append(a.text.replace(' ', '_') + ' ' + url)
                     # print(a.text + ' ' + url)
 
                 result_search = '\n'.join(wiki_list)

--- a/src/tool/__init__.py
+++ b/src/tool/__init__.py
@@ -1,1 +1,2 @@
 from . import p_number
+from . import recover

--- a/src/tool/p_number.py
+++ b/src/tool/p_number.py
@@ -88,7 +88,7 @@ class ProductNumber:
             if match:
                 p_number = match.group().upper()
             else:
-                raise Exception('matchするp_numberがないよー')
+                raise Exception('matchStr[' + match_maker.matchStr + '] するp_numberがないよー [' + title + ']')
 
         return p_number
 
@@ -103,6 +103,7 @@ class ProductNumber:
     #   -3 : メーカー一致が複数件、match_strに一致するmaker無し
     #   -4 : メーカー一致が複数件、match_strに複数件、レーベルに一致するmaker無し
     #   -5 : メーカー・レーベルのどちらにも複数一致
+    #   -6 : -2の中、メーカー名1件だけ完全一致したが、match_strの文字列がtitleにない（Exception発生）
     def __get_maker_exist_name(self, maker_name: str = '', label_name: str = '', title: str = ''):
 
         result_maker = None
@@ -130,7 +131,14 @@ class ProductNumber:
                 ng_reason = 1
                 result_maker = match_maker
                 self.__log_print('OK メーカー完全一致と、タイトル内に製品番号一致 [' + maker_name + ']' + title)
-                p_number = self.get_maker_match_number(match_maker, title)
+                try:
+                    p_number = self.get_maker_match_number(match_maker, title)
+                except Exception as err:
+                    # print('Exception jav maker [' + maker_name + '] label [' + label_name + '] title [' + title + ']' + str(err))
+                    ng_reason = -6
+                    self.__log_print('NG メーカー完全一致だが、タイトル内に製品番号が一致しない [' + maker_name + ']' + title)
+                    p_number = self.__get_p_number(title)
+
             else:
                 ng_reason = -2
                 self.__log_print('NG メーカー完全一致だが、タイトル内に製品番号が一致しない [' + maker_name + ']' + title)

--- a/src/tool/recover.py
+++ b/src/tool/recover.py
@@ -1,0 +1,182 @@
+import re
+import traceback
+from .. import common
+from .. import db
+from .. import data
+from .. import site
+from .. import tool
+
+
+class RecoverError(Exception):
+    pass
+
+
+class Recover:
+
+    def __init__(self, is_log_print: bool = True, is_dry_run: bool = True, makers: list = None):
+        self.p_tool = tool.p_number.ProductNumber(is_log_print=False)
+        self.makers = []
+
+        self.is_log_print = is_log_print
+        self.log_list = []
+        self.is_dry_run = is_dry_run
+
+        self.maker_dao = db.maker.MakerDao()
+        self.jav_dao = db.jav.JavDao()
+
+        if makers is None:
+            self.makers = self.maker_dao.get_all()
+        else:
+            self.makers = makers
+
+        self.parser = common.AutoMakerParser()
+        self.fanza = site.fanza.Fanza()
+        self.fc2 = site.fc2.Fc2()
+        self.hey = site.hey.Hey()
+        self.mgs = site.mgs.Mgs()
+
+        self.filter_makers = list(filter(lambda maker:
+                                         len(maker.matchProductNumber.strip()) > 0
+                                         and len(maker.matchStr) > 0, self.makers))
+
+        self.err_list = []
+
+    def get_error_detail(self):
+
+        return self.err_list
+
+    def append_maker(self, maker_data: data.MakerData() = None):
+
+        self.makers.append(maker_data)
+
+    def __log_print(self, msg: str = ''):
+
+        if self.is_log_print:
+            print(msg)
+        else:
+            self.log_list.append(msg)
+
+    def get_log_print(self):
+
+        log_list = self.log_list.copy()
+        self.log_list.clear()
+
+    def is_not_dry_run(self):
+
+        if self.is_dry_run is None or self.is_dry_run:
+            return False
+
+        return True
+
+    def get_ng_new_maker(self, p_number: str = '', ng_reason: int = 0, jav: data.JavData() = None):
+        """
+        新規登録するメーカーのチェック
+
+        :param p_number:
+        :param ng_reason:
+        :param jav:
+        :return:
+        """
+
+        new_maker = None
+
+        # -1 : メーカー名に一致するmaker無し
+        # -3 : メーカー一致が複数件、match_strに一致するmaker無し
+        #   メーカーに登録
+        # -2 : メーカー名1件だけ完全一致したが、match_strの文字列がtitleにない
+        #   match_strに完全一致のメーカーをdelete:1にして、新規としてメーカーに登録
+        if ng_reason == -1 or ng_reason == -2 or ng_reason == -3:
+            if ng_reason == -2:
+                self.err_list.append('-2発生、1件一致の[' + jav.productNumber + ']deletedを1にする必要あり')
+
+                # deleted : 1 に更新
+                # arr_match_str = jav.productNumber.split('-')
+                # makers = self.maker_dao.get_where_agreement('WHERE match_str = %s', (arr_match_str[0]))
+                # if makers is not None and len(makers) == 1:
+                #     if self.is_not_dry_run():
+                #         self.maker_dao.update_deleted(1, makers[0])
+                # else:
+                #     self.err_list.append('-2発生、1件一致のmaker [' + jav.productNumber + '] 発見できず')
+            try:
+                new_maker = self.parser.get_maker(jav)
+                # self.p_tool.append_maker(new_maker)
+            except common.MatchStrSameError as err:
+                self.err_list.append('MatchStrがscraping.makerに既に存在' + str(err))
+                raise RecoverError('-1から-3でMatchStrSameError発生')
+
+        #   -21 : タイトル内にpNumberは存在したが、一致するメーカーは存在しない
+        if ng_reason == -21:
+            hey_p_number, hey_label = self.p_tool.get_p_number_hey(jav.title)
+
+            if len(hey_p_number) > 0:
+
+                self.err_list.append('      [' + hey_p_number + '] 【' + hey_label + '】')
+                site_data = self.hey.get_info(hey_p_number)
+                if site_data is None or len(site_data.maker) <= 0:
+                    self.err_list.append('      HEYのp_number[ ' + hey_p_number + ']だが、HEYのサイトには存在しない ' + jav.title)
+                    raise RecoverError('-21でHEYのサイトで詳細が存在しないため発生')
+
+                makers = self.maker_dao.get_where_agreement('WHERE label = %s', (site_data.maker, ))
+
+                if makers is not None:
+                    self.err_list.append('      [' + site_data.streamDate + '] 【' + site_data.maker + '】')
+                    self.err_list.append('      HEY【' + site_data.maker + '】はmakerに存在 maker_id ['
+                                         + str(makers[0].id) + ']')
+                    raise RecoverError('-21でHEYでmakerに同様の提供元が存在で発生')
+
+                self.err_list.append('      [' + site_data.streamDate + '] 【' + site_data.maker + '】')
+                new_maker = self.parser.get_maker_hey(hey_p_number, site_data)
+
+            else:
+                site_data = self.mgs.get_info(jav.productNumber)
+
+                site_name = 'MGS'
+                if site_data is None or len(site_data.productNumber) <= 0:
+                    self.err_list.append('      MGSには存在しない ' + jav.title)
+                    site_data = self.fanza.get_info(p_number)
+                    if site_data is None:
+                        self.err_list.append('    FANZAにも存在しない')
+                        raise RecoverError('-21でFANZAのサイトには未存在で発生')
+
+                    site_name = 'FANZA'
+                    site_data.productNumber = jav.productNumber
+                try:
+                    new_maker = self.parser.get_maker_from_site(site_data, site_name)
+                except common.MatchStrNotFoundError as err:
+                    self.err_list.append('MatchStrがタイトル内に存在しない' + str(err) + jav.title)
+                    raise RecoverError('-21でMatchStrNotFoundError発生')
+
+        # maker、labelを更新
+        # -22 : タイトル内にpNumberは存在、複数件のメーカーが一致
+        if ng_reason == -22:
+            site_data = self.fanza.get_info(p_number)
+            if site_data is None:
+                self.err_list.append('    FANZAには存在しない')
+            else:
+                self.err_list.append('    FANZA 【' + site_data.streamDate + '】')
+                # if self.is_not_dry_run():
+                #     if len(jav.maker) <= 0:
+                #         self.jav_dao.update_maker_label(site_data.maker, site_data.label, jav.id)
+
+        # productNumberを更新
+        # -21 : タイトル内にpNumberは存在したが、一致するメーカーは存在しない
+        # -22 : タイトル内にpNumberは存在、複数件のメーカーが一致
+        # -23 : タイトル内にpNumberらしき文字列【[0-9A-Za-z]*-[0-9A-Za-z]】*が存在しない
+        # if ng_reason == -21 or ng_reason == -22 or ng_reason == -23:
+        #     if p_number != jav.productNumber:
+        #         self.err_list.append('  p_number change [' + p_number + '] <-- [' + jav.productNumber + ']')
+        #        # if self.is_not_dry_run():
+        #        #     self.jav_dao.update_product_number(jav.id, p_number)
+
+        if new_maker is not None:
+            if len(list(filter(lambda maker: maker.matchStr.upper() == new_maker.matchStr.upper(), self.makers))) > 0:
+                self.err_list.append('new_makerのmatch_str[' + new_maker.matchStr + ']は既にscraping.makerに存在')
+                raise RecoverError('new_makerのmatch_strは既にscraping.makerに存在')
+        '''
+        if new_maker is not None:
+            new_maker.print('NEW ')
+            if self.is_not_dry_run():
+                self.maker_dao.export(new_maker)
+        '''
+        return new_maker
+

--- a/test/test_recover.py
+++ b/test/test_recover.py
@@ -45,7 +45,7 @@ class TestRecover(unittest.TestCase):
         jav.title = 'MYAB-004 TESTTESTTES'
         jav.productNumber = 'MYAB-004'
         jav.maker = 'Maker Name'
-        new_maker = self.recover.get_ng_new_maker('MYAB-004', -1, jav)
+        new_maker, site_data = self.recover.get_ng_new_maker('MYAB-004', -1, jav)
 
         self.assertEqual('Maker Name', new_maker.name)
 
@@ -92,7 +92,7 @@ class TestRecover(unittest.TestCase):
 
         jav.title = '326MEM-009 RURU'
         jav.productNumber = '326MEM-009'
-        new_maker = self.recover.get_ng_new_maker('326MEM-009', -21, jav)
+        new_maker, site_data = self.recover.get_ng_new_maker('326MEM-009', -21, jav)
         new_maker.print('NEW ')
 
         self.assertEqual('MGS', new_maker.name)
@@ -105,7 +105,7 @@ class TestRecover(unittest.TestCase):
 
         jav.title = 'DACV-085 40NIN 8ZIKAN'
         jav.productNumber = 'DACV-085'
-        new_maker = self.recover.get_ng_new_maker('DACV-085', -21, jav)
+        new_maker, site_data = self.recover.get_ng_new_maker('DACV-085', -21, jav)
         new_maker.print('NEW ')
 
         self.assertEqual('センタービレッジ', new_maker.name)
@@ -120,7 +120,7 @@ class TestRecover(unittest.TestCase):
         jav.productNumber = 'TITG-014'
 
         with self.assertRaises(tool.recover.RecoverError) as cm:
-            new_maker = self.recover.get_ng_new_maker('TITG-014', -21, jav)
+            new_maker, site_data = self.recover.get_ng_new_maker('TITG-014', -21, jav)
             new_maker.print('NEW ')
 
         self.assertEqual(cm.exception.args[0], 'new_makerのmatch_strは既にscraping.makerに存在')

--- a/test/test_recover.py
+++ b/test/test_recover.py
@@ -1,0 +1,130 @@
+import unittest
+from src import common
+from src import data
+from src import tool
+
+
+# PYTHONPATH=. python test/test_common.py -v
+class TestRecover(unittest.TestCase):
+
+    def setUp(self):
+        makers = []
+        maker = data.MakerData()
+        maker.matchName = 'FC2'
+        maker.matchStr = 'FC2'
+        maker.matchProductNumber = '[0-9]{6}'
+        maker.replaceWords = 'PPV'
+        makers.append(maker)
+
+        maker = data.MakerData()
+        maker.name = 'HEY動画'
+        maker.matchName = 'AV9898'
+        maker.label = 'AV9898'
+        maker.matchLabel = 'AV9898'
+        maker.kind = 'AV9898'
+        maker.matchStr = '(4030|AV9898)'
+        maker.matchProductNumber = 'PPV[0-9]{4}'
+        maker.replaceWords = 'PPV'
+        maker.pNumberGen = 1
+        makers.append(maker)
+
+        maker = data.MakerData()
+        maker.name = 'ゲインコーポレーション'
+        maker.matchName = 'ゲインコーポレーション'
+        maker.label = 'gain corporation'
+        maker.matchLabel = 'gain corporation'
+        maker.kind = '1'
+        maker.matchStr = 'TITG'
+        makers.append(maker)
+
+        self.recover = tool.recover.Recover(makers=makers)
+
+    def test_ng_new_maker_minus1(self):
+        jav = data.JavData()
+
+        jav.title = 'MYAB-004 TESTTESTTES'
+        jav.productNumber = 'MYAB-004'
+        jav.maker = 'Maker Name'
+        new_maker = self.recover.get_ng_new_maker('MYAB-004', -1, jav)
+
+        self.assertEqual('Maker Name', new_maker.name)
+
+    '''
+    def test_ng_new_maker_minus4(self):
+        # 14928 SHE-626
+        jav = data.JavData()
+
+        jav.title = 'SHE-626 KIRE'
+        jav.productNumber = 'SHE-626'
+        jav.maker = 'Maker Name'
+        new_maker = self.recover.get_ng_new_maker(-1, jav)
+    '''
+
+        # self.assertEqual('Maker Name', new_maker.name)
+
+    def test_ng_new_maker_minus21_hey_raise_not_site_info(self):
+        #   -21 : タイトル内にpNumberは存在したが、一致するメーカーは存在しない
+        jav = data.JavData()
+
+        jav.title = 'TEST 4999-9999 える！ガル！転落'
+        jav.productNumber = '4999-9999'
+        jav.maker = 'Maker Name'
+        with self.assertRaises(tool.recover.RecoverError) as cm:
+            self.recover.get_ng_new_maker('4999-9999', -21, jav)
+
+        self.assertEqual(cm.exception.args[0], '-21でHEYのサイトで詳細が存在しないため発生')
+
+    def test_ng_new_maker_minus21_hey_raise_maker_exist(self):
+        #   -21 : タイトル内にpNumberは存在したが、一致するメーカーは存在しない
+        jav = data.JavData()
+
+        jav.title = 'av9898 4030-2075 える！ガル！転落'
+        jav.productNumber = '4030-2075'
+        jav.maker = 'Maker Name'
+        with self.assertRaises(tool.recover.RecoverError) as cm:
+            self.recover.get_ng_new_maker('4030-2075', -21, jav)
+
+        self.assertEqual(cm.exception.args[0], '-21でHEYでmakerに同様の提供元が存在で発生')
+
+    def test_ng_new_maker_minus21_mgs_exist(self):
+        #   -21 : タイトル内にpNumberは存在したが、一致するメーカーは存在しない
+        jav = data.JavData()
+
+        jav.title = '326MEM-009 RURU'
+        jav.productNumber = '326MEM-009'
+        new_maker = self.recover.get_ng_new_maker('326MEM-009', -21, jav)
+        new_maker.print('NEW ')
+
+        self.assertEqual('MGS', new_maker.name)
+        self.assertEqual('黒船', new_maker.label)
+
+    def test_ng_new_maker_minus21_mgs_not_exist(self):
+        #   -21 : タイトル内にpNumberは存在したが、一致するメーカーは存在しない
+        # FANZAから取得出来るメーカー名とレーベルが同じ場合は、レーベル名を消す
+        jav = data.JavData()
+
+        jav.title = 'DACV-085 40NIN 8ZIKAN'
+        jav.productNumber = 'DACV-085'
+        new_maker = self.recover.get_ng_new_maker('DACV-085', -21, jav)
+        new_maker.print('NEW ')
+
+        self.assertEqual('センタービレッジ', new_maker.name)
+        self.assertEqual('', new_maker.label)
+
+    def test_ng_new_maker_minus21_fanza_same_raise(self):
+        #   -21 : タイトル内にpNumberは存在したが、一致するメーカーは存在しない
+        # FANZAから取得出来るメーカー名とレーベルが同じ場合は、レーベル名を消す
+        jav = data.JavData()
+
+        jav.title = 'TITG-014 SOKU RUI'
+        jav.productNumber = 'TITG-014'
+
+        with self.assertRaises(tool.recover.RecoverError) as cm:
+            new_maker = self.recover.get_ng_new_maker('TITG-014', -21, jav)
+            new_maker.print('NEW ')
+
+        self.assertEqual(cm.exception.args[0], 'new_makerのmatch_strは既にscraping.makerに存在')
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
tool/recover.pyで新規新規登録メーカのチェック処理を追加
tool/recover.pyのテストコードtest_recover.pyを追加
SiteInfoCollect, SiteInfoGetterでサイト情報の取得を一元化
confirm_site, confirm_recover2作成
import_jav_id列追加
maker.site_kindの3,4の対応
各種のエラー処理の追加